### PR TITLE
Tinyint range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sourceforge.jtds</groupId>
     <artifactId>jtds</artifactId>
-    <version>1.3.1-IB-14</version>
+    <version>1.3.1-IB-15-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>jTDS</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sourceforge.jtds</groupId>
     <artifactId>jtds</artifactId>
-    <version>1.3.1-IB-15-SNAPSHOT</version>
+    <version>1.3.1-IB-15</version>
     <packaging>pom</packaging>
     <name>jTDS</name>
 

--- a/src/main/net/sourceforge/jtds/jdbc/Support.java
+++ b/src/main/net/sourceforge/jtds/jdbc/Support.java
@@ -256,7 +256,8 @@ public class Support {
                         } else {
                             break;
                         }
-                        if (val < Byte.MIN_VALUE || val > Byte.MAX_VALUE) {
+                        // if (val < Byte.MIN_VALUE || val > Byte.MAX_VALUE) {
+                        if (val < Byte.MIN_VALUE || val > 255) {
                             throw new SQLException(Messages.get("error.convert.numericoverflow", x, getJdbcTypeName(jdbcType)), "22003");
                         } else {
                             return new Integer(new Long(val).intValue());

--- a/src/test/net/sourceforge/jtds/jdbc/ResultSetTest.java
+++ b/src/test/net/sourceforge/jtds/jdbc/ResultSetTest.java
@@ -2031,8 +2031,9 @@ public class ResultSetTest extends DatabaseTestCase {
         Statement st = con.createStatement();
         st.execute("create table #testNegativeOverflow(data int)");
 
-        int    [] values   = new int    [] {   -1,  -128, -129,   127,  128};
-        boolean[] overflow = new boolean[] {false, false, true, false, true};
+        int    [] values   = new int    [] {   -1,  -128, -129,   127,   128,   255,  256};
+        boolean[] overflow = new boolean[] {false, false, true, false, false, false, true};
+        int    [] expected = new int    [] {   -1,  -128,    0,   127,  -128,  -1,  0};
 
         for (int i = 0; i < values.length; i++) {
             assertEquals(1, st.executeUpdate("insert into #testNegativeOverflow values (" + values[i] + ")"));
@@ -2045,6 +2046,7 @@ public class ResultSetTest extends DatabaseTestCase {
             try {
                 byte b = rs.getByte(1);
                 assertFalse("expected numeric overflow error for value " + values[i] + ", got " + b, overflow[i]);
+		assertEquals(expected[i], b);
             } catch (SQLException e) {
                 assertTrue("unexpected numeric overflow for value " + values[i], overflow[i]);
             }


### PR DESCRIPTION
Allow a higher upper bound for tinyint data type. Apparenty, MSSQL handles it fine.